### PR TITLE
hearts fix

### DIFF
--- a/gui/bars/lifebar.gd
+++ b/gui/bars/lifebar.gd
@@ -2,7 +2,6 @@ extends HBoxContainer
 
 @onready var heart_gui_class = preload("res://gui/parts/heart.tscn")
 
-
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	pass # Replace with function body.
@@ -18,8 +17,10 @@ func set_max_hearts(maxNum: int) -> void:
 		add_child(heart)
 		
 
-func update_hearts(current_health: int):
+func update_hearts():
+#func update_hearts(current_health: int):
 	var hearts = get_children()
+	var current_health = GamemodeHandler.health
 	
 	for heart in hearts:
 		heart.update("full")
@@ -29,7 +30,6 @@ func update_hearts(current_health: int):
 	
 func _on_player_damaged():
 	print("Current Health: " + str(GamemodeHandler.health))
-	print("Current Health: " + str(GamemodeHandler.health))
-	update_hearts(GamemodeHandler.health)
+	update_hearts()
 	print("Current Health: " + str(GamemodeHandler.health))
 	

--- a/gui/bars/stambar.gd
+++ b/gui/bars/stambar.gd
@@ -23,12 +23,12 @@ func _process(_delta: float) -> void:
 
 func set_max_stamina(maxNum: int) -> void:
 	for i in range(maxNum):
-		var heart = stam_gui_class.instantiate()
-		add_child(heart)
+		var fish = stam_gui_class.instantiate()
+		add_child(fish)
 
 
 func update_stamina(current_health: int):
-	var hearts = get_children()
+	var fishes = get_children()
 	
-	for heart in hearts:
-		heart.update("full")
+	for fish in fishes:
+		fish.update("full")

--- a/gui/parts/heart.gd
+++ b/gui/parts/heart.gd
@@ -15,4 +15,8 @@ func _process(_delta: float) -> void:
 # 0: Empty
 # 1: Full
 func update(animation: String):
-	sprite.play(animation)
+	$heart.play(animation)
+	if animation == "empty":
+		sprite.visible = false
+	else:
+		sprite.visible = true

--- a/mob/player/player.gd
+++ b/mob/player/player.gd
@@ -7,9 +7,18 @@ var isFreezed = false
 @export var gamemode = 0
 
 @onready var hearts_container = $ui_layer/lifebar
+var instantiated = false
 
 
 var fishes: int = 4
+
+func _enter_tree():
+	print("Player entered tree")
+	#if GamemodeHandler.health > 0:
+		#print("updated hearts")
+		#hearts_container.update_hearts()
+	#if instantiated:
+		#print("entered tree")
 
 func _physics_process(delta):
 	if not isFreezed:
@@ -106,12 +115,14 @@ func _physics_process(delta):
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	hearts_container.set_max_hearts(7)
+	instantiated = true
 
 
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):
+	#hearts_container.update_hearts()
 	pass
 
 
@@ -137,7 +148,8 @@ func _on_object_player_damaged() -> void:
 
 func get_damage():
 	GamemodeHandler._on_player_damaged()
-	hearts_container.update_hearts(GamemodeHandler.health)
+	hearts_container.update_hearts()
+	#hearts_container.update_hearts(GamemodeHandler.health)
 	print(str(GamemodeHandler.health) + " health remaining.")
 	
 

--- a/scenes/Dungeon.tscn
+++ b/scenes/Dungeon.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=17 format=4 uid="uid://fetm1t81vuin"]
+[gd_scene load_steps=18 format=4 uid="uid://fetm1t81vuin"]
 
+[ext_resource type="Script" path="res://scenes/dungeon.gd" id="1_hary6"]
 [ext_resource type="Texture2D" uid="uid://cr52pq1wuml0p" path="res://images/Tilemaps/worlds/mountain background/Mountain-Dusk.png" id="1_ubdn3"]
 [ext_resource type="Texture2D" uid="uid://ncr406ndikxp" path="res://images/Tilemaps/worlds/water/background/sand.png" id="2_roess"]
 [ext_resource type="PackedScene" uid="uid://c24kk85efm6h1" path="res://scenes/Inventory/items/postcard.tscn" id="3_x8e5v"]
@@ -2775,6 +2776,7 @@ sources/2 = SubResource("TileSetAtlasSource_6gn75")
 sources/3 = SubResource("TileSetAtlasSource_xe83m")
 
 [node name="Node2D" type="Node2D"]
+script = ExtResource("1_hary6")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 visible = false

--- a/scenes/Mountains.tscn
+++ b/scenes/Mountains.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=24 format=4 uid="uid://cch4in63nidla"]
+[gd_scene load_steps=25 format=4 uid="uid://cch4in63nidla"]
 
 [ext_resource type="Texture2D" uid="uid://cr52pq1wuml0p" path="res://images/Tilemaps/worlds/mountain background/Mountain-Dusk.png" id="1_f10bt"]
+[ext_resource type="Script" path="res://scenes/mountains.gd" id="1_kc2up"]
 [ext_resource type="Texture2D" uid="uid://ncr406ndikxp" path="res://images/Tilemaps/worlds/water/background/sand.png" id="2_biyvc"]
 [ext_resource type="PackedScene" uid="uid://c24kk85efm6h1" path="res://scenes/Inventory/items/postcard.tscn" id="3_djkml"]
 [ext_resource type="PackedScene" uid="uid://egesikv1ec5t" path="res://mob/player/player.tscn" id="4_lp8h1"]
@@ -1233,6 +1234,7 @@ sources/9 = SubResource("TileSetAtlasSource_l2sas")
 sources/10 = SubResource("TileSetAtlasSource_db7aa")
 
 [node name="Node2D" type="Node2D"]
+script = ExtResource("1_kc2up")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 visible = false

--- a/scenes/Underwater.tscn
+++ b/scenes/Underwater.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=16 format=4 uid="uid://b74vtdpkay2nv"]
+[gd_scene load_steps=17 format=4 uid="uid://b74vtdpkay2nv"]
 
 [ext_resource type="Texture2D" uid="uid://ncr406ndikxp" path="res://images/Tilemaps/worlds/water/background/sand.png" id="1_3vnpc"]
+[ext_resource type="Script" path="res://scenes/underwater.gd" id="1_xajuq"]
 [ext_resource type="PackedScene" uid="uid://c24kk85efm6h1" path="res://scenes/Inventory/items/postcard.tscn" id="7_1tlrk"]
 [ext_resource type="PackedScene" uid="uid://egesikv1ec5t" path="res://mob/player/player.tscn" id="8_p7uvn"]
 [ext_resource type="PackedScene" uid="uid://bgt0e6rxsslqm" path="res://scenes/entrance_template_interactable.tscn" id="10_butik"]
@@ -125,6 +126,7 @@ sources/1 = SubResource("TileSetAtlasSource_cv3c4")
 sources/2 = SubResource("TileSetAtlasSource_bysp0")
 
 [node name="Node2D2" type="Node2D"]
+script = ExtResource("1_xajuq")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(425.306, 394.684)

--- a/scenes/dungeon.gd
+++ b/scenes/dungeon.gd
@@ -1,0 +1,12 @@
+extends Node2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	$Player.hearts_container.update_hearts()
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/scenes/main_scene.gd
+++ b/scenes/main_scene.gd
@@ -1,0 +1,12 @@
+extends Node2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	$Player.hearts_container.update_hearts()
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/scenes/main_scene.tscn
+++ b/scenes/main_scene.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=41 format=4 uid="uid://bcf6c0ghkv687"]
+[gd_scene load_steps=42 format=4 uid="uid://bcf6c0ghkv687"]
 
 [ext_resource type="PackedScene" path="res://gui/default_ui.tscn" id="1_0ryrq"]
+[ext_resource type="Script" path="res://scenes/main_scene.gd" id="1_r77k3"]
 [ext_resource type="Texture2D" uid="uid://qii51n4l2jdk" path="res://images/Tilemaps/TopDown/Terrain/plains.png" id="2_chao5"]
 [ext_resource type="Texture2D" uid="uid://vmjxrax42nii" path="res://images/Tilemaps/TopDown/Terrain/Cliffs.png" id="3_3fu24"]
 [ext_resource type="Texture2D" uid="uid://bebgcabrinpi2" path="res://images/Tilemaps/TopDown/Objects/trees_small.png" id="3_dg7d8"]
@@ -1389,6 +1390,7 @@ sources/0 = SubResource("TileSetAtlasSource_5qokn")
 sources/1 = SubResource("TileSetAtlasSource_yb6m2")
 
 [node name="Node2D2" type="Node2D"]
+script = ExtResource("1_r77k3")
 
 [node name="DefaultUIElements" parent="." instance=ExtResource("1_0ryrq")]
 

--- a/scenes/mountains.gd
+++ b/scenes/mountains.gd
@@ -1,0 +1,12 @@
+extends Node2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	$Player.hearts_container.update_hearts()
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/scenes/underwater.gd
+++ b/scenes/underwater.gd
@@ -1,0 +1,12 @@
+extends Node2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	$Player.hearts_container.update_hearts()
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/scripts/gamemode_handler.gd
+++ b/scripts/gamemode_handler.gd
@@ -19,6 +19,17 @@ func _on_player_damaged():
 	health = health - 1
 	if health > 0:
 		get_tree().reload_current_scene()
+		
+		#var player
+		#player = get_node("Player")
+		#player.find_child("ui_layer/lifebar").update_hearts()
+		#var player
+		#player = find_child("Player", true)  # Zuweisung separat
+		#if player:
+			#print("Player gefunden")
+			#print(player.hearts_container)
+		#var hearts_container = $ui_layer/lifebar
+		#$Player.hearts_container.update_hearts()
 	else:
 		death()
 	print("remaining health: " + str(health))


### PR DESCRIPTION
- Beim Scenenwechsel werden die Animationen der hearts wieder auf "full" geladen. Deswegen muss man in jeder scene in der es auch einen Player gibt "$Player.hearts_container.update_hearts()"
hinzufügen